### PR TITLE
fix(package): upgrade dependencies to latest

### DIFF
--- a/lib/mimetype.js
+++ b/lib/mimetype.js
@@ -4,9 +4,9 @@ const mime = require('mime');
 
 class Mimetype {
   static getWithCharset(localFile, stat, callback) {
-    const mimeType = mime.lookup(localFile);
-    const charset = mime.charsets.lookup(mimeType);
-    const ContentType = charset ? mimeType + '; charset=' + charset.toLowerCase() : mimeType;
+    const mimeType = mime.getType(localFile);
+    const charset = mimeType.indexOf('text/') === 0 ? 'utf-8' : null;
+    const ContentType = charset ? mimeType + '; charset=' + charset : mimeType;
     callback(null, { ContentType });
   }
 }

--- a/lib/mimetype.spec.js
+++ b/lib/mimetype.spec.js
@@ -1,12 +1,15 @@
 'use strict';
 
 const mockFS = require('mock-fs');
-const mime = require('mime');
 const Mimetype = require('./mimetype');
 
 describe('Mimetype', function() {
-  let fileMock = { 'test.txt': 'content' };
-  let filePathMock = Object.keys(fileMock)[0];
+  let fileMock = {
+    'test.txt': 'content',
+    'image.jpg': 'IMAGE'
+  };
+  let textFilePathMock = Object.keys(fileMock)[0];
+  let imageFilePathMock = Object.keys(fileMock)[1];
 
   describe('#getWithCharset', function() {
     beforeEach(function() {
@@ -20,18 +23,16 @@ describe('Mimetype', function() {
     it('should call given callback with correct mimetype and charset', function() {
       let callbackStub = this.sandbox.stub();
 
-      Mimetype.getWithCharset(filePathMock, null, callbackStub);
+      Mimetype.getWithCharset(textFilePathMock, null, callbackStub);
       let expectedCallbackMock = { ContentType: 'text/plain; charset=utf-8' };
       expect(callbackStub).to.be.calledWith(null, expectedCallbackMock);
     });
 
     it('should call given callback with correct mimetype if charset lookup fails', function() {
-      this.sandbox.stub(mime.charsets, 'lookup').returns(false);
-
       let callbackStub = this.sandbox.stub();
 
-      Mimetype.getWithCharset(filePathMock, null, callbackStub);
-      let expectedCallbackMock = { ContentType: 'text/plain' };
+      Mimetype.getWithCharset(imageFilePathMock, null, callbackStub);
+      let expectedCallbackMock = { ContentType: 'image/jpeg' };
       expect(callbackStub).to.be.calledWith(null, expectedCallbackMock);
     });
   });

--- a/package.json
+++ b/package.json
@@ -34,22 +34,22 @@
   "dependencies": {
     "child-process-promise": "2.2.1",
     "glob": "7.1.2",
-    "inquirer": "3.2.1",
-    "mime": "1.3.6",
+    "inquirer": "5.2.0",
+    "mime": "2.3.1",
     "rename": "1.0.4",
     "s3": "4.4.0",
-    "superagent": "3.5.2",
-    "yargs": "8.0.2"
+    "superagent": "3.8.3",
+    "yargs": "11.0.0"
   },
   "devDependencies": {
-    "chai": "4.1.1",
-    "co-mocha": "1.2.0",
-    "eslint": "4.4.1",
-    "eslint-config-emarsys": "4.0.0",
-    "mocha": "3.5.0",
-    "mock-fs": "4.4.1",
-    "semantic-release": "7.0.2",
-    "sinon": "3.2.0",
-    "sinon-chai": "2.13.0"
+    "chai": "4.1.2",
+    "co-mocha": "1.2.2",
+    "eslint": "4.19.1",
+    "eslint-config-emarsys": "5.1.0",
+    "mocha": "5.2.0",
+    "mock-fs": "4.5.0",
+    "semantic-release": "15.5.0",
+    "sinon": "5.0.10",
+    "sinon-chai": "3.1.0"
   }
 }

--- a/setup-tests.spec.js
+++ b/setup-tests.spec.js
@@ -12,7 +12,7 @@ before(function() {
 });
 
 beforeEach(function() {
-  this.sandbox = sinon.sandbox.create();
+  this.sandbox = sinon.createSandbox();
   this.sinon = sinon;
 });
 


### PR DESCRIPTION
Since mime removed support for charset (the reason was it had a garbage code behind and like always returned UTF-8 for text/* type), I had to reimplement the same logic there.