### PR TITLE
fix(mimetype): fix missing charset on certain non-text mime types

### DIFF
--- a/lib/mimetype.js
+++ b/lib/mimetype.js
@@ -5,7 +5,7 @@ const mime = require('mime');
 class Mimetype {
   static getWithCharset(localFile, stat, callback) {
     const mimeType = mime.getType(localFile);
-    const charset = mimeType.indexOf('text/') === 0 ? 'utf-8' : null;
+    const charset = (/^text\/|^application\/(javascript|json)/).test(mimeType) ? 'utf-8' : null;
     const ContentType = charset ? mimeType + '; charset=' + charset : mimeType;
     callback(null, { ContentType });
   }

--- a/lib/mimetype.spec.js
+++ b/lib/mimetype.spec.js
@@ -1,39 +1,45 @@
 'use strict';
 
-const mockFS = require('mock-fs');
 const Mimetype = require('./mimetype');
 
-describe('Mimetype', function() {
-  let fileMock = {
-    'test.txt': 'content',
-    'image.jpg': 'IMAGE'
-  };
-  let textFilePathMock = Object.keys(fileMock)[0];
-  let imageFilePathMock = Object.keys(fileMock)[1];
+describe('Mimetype', () => {
+  describe('#getWithCharset', () => {
+    [
+      {
+        should: 'call given callback with correct mimetype',
+        file: 'test.jpg',
+        expectedContentType: 'image/jpeg'
+      },
+      {
+        should: 'append charset=utf-8 if mime type starts with text',
+        file: 'test.txt',
+        expectedContentType: 'text/plain; charset=utf-8'
+      },
+      {
+        should: 'append charset=utf-8 if file type is css',
+        file: 'test.css',
+        expectedContentType: 'text/css; charset=utf-8'
+      },
+      {
+        should: 'append charset=utf-8 if mime type is application/javascript',
+        file: 'test.js',
+        expectedContentType: 'application/javascript; charset=utf-8'
+      },
+      {
+        should: 'append charset=utf-8 if mime type is application/json',
+        file: 'test.json',
+        expectedContentType: 'application/json; charset=utf-8'
+      }
+    ].forEach((testCase) => {
+      it(`should ${testCase.should}`, function() {
+        const callbackStub = this.sandbox.stub();
 
-  describe('#getWithCharset', function() {
-    beforeEach(function() {
-      mockFS(fileMock);
-    });
+        Mimetype.getWithCharset(testCase.file, null, callbackStub);
 
-    afterEach(function() {
-      mockFS.restore();
-    });
-
-    it('should call given callback with correct mimetype and charset', function() {
-      let callbackStub = this.sandbox.stub();
-
-      Mimetype.getWithCharset(textFilePathMock, null, callbackStub);
-      let expectedCallbackMock = { ContentType: 'text/plain; charset=utf-8' };
-      expect(callbackStub).to.be.calledWith(null, expectedCallbackMock);
-    });
-
-    it('should call given callback with correct mimetype if charset lookup fails', function() {
-      let callbackStub = this.sandbox.stub();
-
-      Mimetype.getWithCharset(imageFilePathMock, null, callbackStub);
-      let expectedCallbackMock = { ContentType: 'image/jpeg' };
-      expect(callbackStub).to.be.calledWith(null, expectedCallbackMock);
+        expect(callbackStub).to.be.calledWith(null, {
+          ContentType: testCase.expectedContentType
+        });
+      });
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3103,9 +3103,9 @@
       }
     },
     "mime": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
-      "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
     },
     "mime-db": {
       "version": "1.44.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "child-process-promise": "2.2.1",
     "glob": "7.1.6",
     "inquirer": "6.5.2",
-    "mime": "2.4.5",
+    "mime": "2.5.2",
     "rename": "1.0.4",
     "superagent": "4.1.0",
     "yargs": "12.0.5"


### PR DESCRIPTION
There was an issue where UTF-8 files were interpreted in other charset because their content-type not specified the UTF-8 charset and the HTML had other encoding.

In our case a JS file was uploaded to S3 with "content-type: application/javascript" without charset=UTF-8 and it caused issues on www env because it uses iso-8859-1.

resolve WMA-456

Co-authored-by: bmori <balint.mori@emarsys.com>